### PR TITLE
Catch UnsupportedOperationException in ServerListPingEvent.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
     <packaging>jar</packaging>
 
     <name>VanishNoPacket</name>
-    <version>3.20.1</version>
+    <version>3.20.2</version>
 
     <url>http://github.com/mbax/VanishNoPacket</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vnp-version>${project.version}-unofficial</vnp-version>
+        <vnp-version>${project.version}-NerdNu</vnp-version>
     </properties>
 
     <profiles>
@@ -126,6 +126,7 @@
     </distributionManagement>
 
     <build>
+        <defaultGoal>clean install</defaultGoal>
         <finalName>${project.artifactId}</finalName>
         <directory>target</directory>
         <resources>

--- a/src/main/java/org/kitteh/vanish/listeners/ListenServerPing.java
+++ b/src/main/java/org/kitteh/vanish/listeners/ListenServerPing.java
@@ -18,13 +18,16 @@ public final class ListenServerPing implements Listener {
 
     @EventHandler
     public void ping(ServerListPingEvent event) {
-        final Set<String> invisibles = this.manager.getVanishedPlayers();
-        final Iterator<Player> players = event.iterator();
-        while (players.hasNext()) {
-            Player player = players.next();
-            if (invisibles.contains(player.getName())) {
-                players.remove();
+        try {
+            final Set<String> invisibles = this.manager.getVanishedPlayers();
+            final Iterator<Player> players = event.iterator();
+            while (players.hasNext()) {
+                Player player = players.next();
+                if (invisibles.contains(player.getName())) {
+                    players.remove();
+                }
             }
+        } catch (UnsupportedOperationException ex) {
         }
     }
 }


### PR DESCRIPTION
Though we usually run on Paper, it's sometimes handy to be able to revert to Spigot.

Spigot throws `UnsupportedOperationException` from `ServerListPingEvent.iterator()`, so catch that.